### PR TITLE
allow registered gas limit mismatch

### DIFF
--- a/src/validation.rs
+++ b/src/validation.rs
@@ -191,7 +191,6 @@ where
         };
 
         self.consensus.validate_header_against_parent(block.sealed_header(), &parent_header)?;
-        self.validate_gas_limit(registered_gas_limit, &parent_header, block.sealed_header())?;
         let parent_header_hash = parent_header.hash();
         let state_provider = self.provider.state_by_block_hash(parent_header_hash)?;
 


### PR DESCRIPTION
This is needed to prevent the relay from rejecting valid blocks from the builder due to a different view of the validators registered limit and is safe to do, as the `validate_header_against_parent` call above already checks the gas limit for consistency between parent and self headers, ensuring that the delta is less than the maximum allowable difference.